### PR TITLE
Add a proposal to govern the (external) contribution process by using CLA's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+As the interest in our SSO implementation grows, we receive requests on how to contribute to our applications... and we are very happy about these requests!
+
+# Our model
+
+We chose to adopt a model similar to that of the Apache Software Foundation, which involves contributors signing and submitting a contributor license agreement. These represent a license that the contributor grants to Hochschule Heilbronn and covers contributions to all of our projects. That is, it is it not limited to 
+Helpdesk or our Welcome application, but also covers a growing set of additional projects.
+
+To this end, we adapted the contributor agreements used at the Apache Software Foundation for our purposes. In particular, we replaced mentions of the Foundation with mentions of the University (Hochschule Heilbronn) and added a clause that the agreement is governed by German law. Please read the license agreements carefully before signing them.
+
+The primary contributor agreement is the Individual Contributor License Agreement which is submitted by each individual contributing person. However, if that person is working under contract, we ask that their employer sign and file an additional Corporate Contributor License Agreement which certifies the consent of the employer with the actions of the contributing person.
+
+We ask that you discuss the topic of contribution with your employer even if you plan to create your contributions in your spare time. Being open from the start will avoid problems later and your employer will likely be happy to sign the corporate contributor license agreement after you have discussed the particulars.
+
+The contributor license agreement represents a license that the contributor gives to Hochschule Heilbronn and which allows us to sublicense the contribution.
+
+The contribution might be a first step towards a more generic extension of the framework which we would eventually like to have licensed under the Apache License to maximize its usability. 
+
+Having separate contributor license agreements allows us to refactor such contributions and to eventually move them from a GPL module to an Apache-licensed module.
+
+# Contributor license agreements
+Details on how and where to submit the agreements are included in their respective texts.
+
+- [Individual Contributor License Agreement (ICLA) - always required](templates/ccla.txt)
+- [Corporate Contributor License Agreement (CCLA) - strongly recommended when contributor is employed](templates/icla.txt)
+
+# How to make contributions
+
+Contributions should be submitted by sending a pull request to the project to which you wish to contribute. If your contribution addresses an existing bug or feature request listed in the project’s issue tracker, please reference it. (If not, consider opening a new issue before sending your pull request.)
+
+Prolific contributors may eventually be granted write access to the code repositories. Access to the repositories is granted on a per-project basis.
+
+# Copyright
+All contributions remain under the copyright of the original authors (or their employers).
+
+# Integrating third-party code
+Code integrated from third parties by others than their original authors may not have any copyright notice, @author tags, nor other kind of attribution removed.
+
+In general, integration of third-party code should be avoided. Instead, the required libraries should be specified as dependencies.
+
+Third-party code that is integrated must be compatible with our license. For Apache-licensed modules, it must be compatible with the Apache license.
+
+# Preparing a pull request
+
+In order to contribute to the project, you need to create a pull request. This section briefly guides you through the best way of doing this:
+ 
+- Before creating a pull request, create an issue in the issue tracker of the project to which you wish to contribute
+- Fork the project on GitHub
+- Create a branch based on the branch to which you wish to contribute. Normally, you should create this branch from the master branch of the respective project. In the case you want to fix a bug in the latest released version, you should consider to branch off the latest maintenance branch (e.g. 1.2.x). If you are not sure, ask via the issue you have just created. Do not make changes directly to the master or maintenance branches in your fork. The name of the branch should be e.g. feature/[ISSUE-NUMBER]-[SHORT-ISSUE-DESCRIPTION] or bugfix/[ISSUE-NUMBER]-[SHORT-ISSUE-DESCRIPTION].
+- Now you make changes to your branch. When committing to your branch, use the format shown below for your commit messages. Note that # normally introduces comments in git. You may have to reconfigure git before attempting an interactive rebase and switch it to another comment character.
+
+```
+#[ISSUE NUMBER] - [ISSUE TITLE]
+[EMPTY LINE]
+- [CHANGE 1]
+- [CHANGE 2]
+- [...]
+```
+- You can create the pull request any time after your first commit. I.e. you do not have to wait until you are completely finished with your implementation. Creating a pull request early tells other developers that you are actively working on an issue and facilitates asking questions about and discussing implementation details.

--- a/templates/ccla.txt
+++ b/templates/ccla.txt
@@ -1,0 +1,153 @@
+Software Grant and Corporate Contributor License Agreement ("Agreement") 
+                               between
+Corporation and the Hochschule Heilbronn ("University") V1.0
+
+(Based on the Apache Software Foundation Software Grant and Corporate
+Contributor License Agreement v r190612)
+
+In order to clarify the intellectual property license
+granted with Contributions from any person or entity, the University
+must have a Contributor License Agreement (CLA) on file that has been
+signed by each Contributor, indicating agreement to the license terms
+below. This license is for your protection as a Contributor as well
+as the protection of the University and its users; it does not change
+your rights to use your own Contributions for any other purpose.
+This version of the Agreement allows an entity (the "Corporation") to
+submit Contributions to the University, to authorize Contributions
+submitted by its designated employees to the University, and to grant
+copyright and patent licenses thereto.
+
+If you have not already done so, please complete and sign, then scan and
+email a pdf file of this Agreement to 
+isb@hs-heilbronn.de. If necessary, send an original signed Agreement to
+Hochschule Heilbronn, Fakultät Informatik, Prof. Dr. Andreas Kurtz,
+Max-Planck-Str. 39, 74081 Heilbronn, Germany.
+
+Please read this document carefully before signing and keep a copy for
+your records.
+
+
+   Corporation name:    ________________________________________________
+
+   Corporation address: ________________________________________________
+
+                        ________________________________________________
+
+                        ________________________________________________
+
+   Point of Contact:    ________________________________________________
+
+          E-Mail:       ________________________________________________
+
+          Telephone:    _____________________ Fax: _____________________
+          
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to the University. In
+return, the University shall not use Your Contributions in a way that
+is contrary to the public benefit. Except for the license granted herein
+to the University and recipients of software distributed by the University,
+You reserve all right, title, and interest in and to Your Contributions.
+
+1. Definitions.
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement
+   with the University. For legal entities, the entity making a
+   Contribution and all other entities that control, are controlled by,
+   or are under common control with that entity are considered to be a
+   single Contributor. For the purposes of this definition, "control"
+   means (i) the power, direct or indirect, to cause the direction or
+   management of such entity, whether by contract or otherwise, or
+   (ii) ownership of fifty percent (50%) or more of the outstanding
+   shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean the code, documentation or other original
+   works of authorship expressly identified in Schedule B, as well as
+   any original work of authorship, including
+   any modifications or additions to an existing work, that is intentionally
+   submitted by You to the University for inclusion in, or
+   documentation of, any of the products owned or managed by the
+   University (the "Work"). For the purposes of this definition,
+   "submitted" means any form of electronic, verbal, or written
+   communication sent to the University or its representatives,
+   including but not limited to communication on electronic mailing
+   lists, source code control systems, and issue tracking systems
+   that are managed by, or on behalf of, the University for the
+   purpose of discussing and improving the Work, but excluding
+   communication that is conspicuously marked or otherwise designated
+   in writing by You as "Not a Contribution."
+   
+2. Grant of Copyright License. Subject to the terms and conditions
+   of this Agreement, You hereby grant to the University and to
+   recipients of software distributed by the University a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare derivative works of,
+   publicly display, publicly perform, sublicense, and distribute
+   Your Contributions and such derivative works.
+   
+3. Grant of Patent License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to the University and to recipients
+   of software distributed by the University a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable (except as
+   stated in this section) patent license to make, have made, use,
+   offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by You that are necessarily infringed by Your Contribution(s)
+   alone or by combination of Your Contribution(s) with the Work to
+   which such Contribution(s) were submitted. If any entity institutes
+   patent litigation against You or any other entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that your
+   Contribution, or the Work to which you have contributed, constitutes
+   direct or contributory patent infringement, then any patent licenses
+   granted to that entity under this Agreement for that Contribution or
+   Work shall terminate as of the date such litigation is filed.
+   
+4. You represent that You are legally entitled to grant the above
+   license. You represent further that each employee of the
+   Corporation designated on Schedule A below (or in a subsequent
+   written modification to that Schedule) is authorized to submit
+   Contributions on behalf of the Corporation.
+   
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others).
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+   MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+   
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to the University separately from any
+   Contribution, identifying the complete details of its source and
+   of any license or other restriction (including, but not limited
+   to, related patents, trademarks, and license agreements) of which
+   you are personally aware, and conspicuously marking the work as
+   "Submitted on behalf of a third-party: [named here]".
+   
+8. It is your responsibility to notify the University when any change
+   is required to the list of designated employees authorized to submit
+   Contributions on behalf of the Corporation, or to the Corporation's
+   Point of Contact with the University.
+   
+9. This Agreement is to be read, construed and governed by the laws of
+   Germany without regard to its conflict of law principles. This 
+   Agreement is prepared and executed and will be interpreted in the
+   English language only, and no translation of the Agreement into
+   another language will have any effect.
+   
+
+   Please sign: __________________________________ Date: _______________
+
+   Title:       __________________________________
+
+   Corporation: __________________________________
+
+
+Schedule A
+
+   [Initial list of designated employees.  NB: authorization is not
+    tied to particular Contributions.]
+

--- a/templates/icla.txt
+++ b/templates/icla.txt
@@ -1,0 +1,144 @@
+         Individual Contributor License Agreement ("Agreement") 
+between You and the Hochschule Heilbronn ("University") V1.0
+
+(Based on the Apache Software Foundation Individual Contributor License
+Agreement ("Agreement") V2.0)
+
+In order to clarify the intellectual property license
+granted with Contributions from any person or entity, the University 
+must have a Contributor License Agreement ("CLA") on file that has
+been signed by each Contributor, indicating agreement to the license
+terms below. This license is for your protection as a Contributor as
+well as the protection of the University and its users; it does not 
+change your rights to use your own Contributions for any other purpose. 
+
+If you have not already done so, please complete and sign, then scan and
+email a pdf file of this Agreement to
+isb@hs-heilbronn.de. If necessary, send an original signed Agreement to
+Hochschule Heilbronn, Fakultät Informatik, Prof. Dr. Andreas Kurtz,
+Max-Planck-Str. 39, 74081 Heilbronn, Germany.
+
+Please read this document carefully before signing and
+keep a copy for your records.
+
+  Full name: ______________________________________________________
+
+  (optional) Public name: _________________________________________
+
+  Mailing Address: ________________________________________________
+
+                   ________________________________________________
+
+  Country:   ______________________________________________________
+
+  Telephone: ______________________________________________________
+
+  E-Mail:    ______________________________________________________
+
+  Contributor id(s):      _________________________________________
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to the University. In
+return, the University shall not use Your Contributions in a way
+that is contrary to the public benefit. Except for the license granted
+herein to the University and recipients of software distributed by
+the University, You reserve all right, title, and interest in and to
+Your Contributions.
+
+1. Definitions.
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement
+   with the University. For legal entities, the entity making a
+   Contribution and all other entities that control, are controlled
+   by, or are under common control with that entity are considered to
+   be a single Contributor. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship,
+   including any modifications or additions to an existing work, that
+   is intentionally submitted by You to the University for inclusion
+   in, or documentation of, any of the products owned or managed by
+   the University (the "Work"). For the purposes of this definition,
+   "submitted" means any form of electronic, verbal, or written
+   communication sent to the University or its representatives,
+   including but not limited to communication on electronic mailing
+   lists, source code control systems, and issue tracking systems that
+   are managed by, or on behalf of, the University for the purpose of
+   discussing and improving the Work, but excluding communication that
+   is conspicuously marked or otherwise designated in writing by You
+   as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to the University and to
+   recipients of software distributed by the University a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare derivative works of,
+   publicly display, publicly perform, sublicense, and distribute Your
+   Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to the University and to
+   recipients of software distributed by the University a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have
+   made, use, offer to sell, sell, import, and otherwise transfer the
+   Work, where such license applies only to those patent claims
+   licensable by You that are necessarily infringed by Your
+   Contribution(s) alone or by combination of Your Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If any
+   entity institutes patent litigation against You or any other entity
+   (including a cross-claim or counterclaim in a lawsuit) alleging
+   that your Contribution, or the Work to which you have contributed,
+   constitutes direct or contributory patent infringement, then any
+   patent licenses granted to that entity under this Agreement for
+   that Contribution or Work shall terminate as of the date such
+   litigation is filed.
+
+4. You represent that you are legally entitled to grant the above
+   license. If your employer(s) has rights to intellectual property
+   that you create that includes your Contributions, you represent
+   that you have received permission to make Contributions on behalf
+   of that employer, that your employer has waived such rights for
+   your Contributions to the University, or that your employer has
+   executed a separate Corporate CLA with the University.
+
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others).  You
+   represent that Your Contribution submissions include complete
+   details of any third-party license or other restriction (including,
+   but not limited to, related patents and trademarks) of which you
+   are personally aware and which are associated with any part of Your
+   Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-
+   INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to the University separately from any
+   Contribution, identifying the complete details of its source and of
+   any license or other restriction (including, but not limited to,
+   related patents, trademarks, and license agreements) of which you
+   are personally aware, and conspicuously marking the work as
+   "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the University of any facts or circumstances of
+   which you become aware that would make these representations
+   inaccurate in any respect.
+
+9. This Agreement is to be read, construed and governed by the laws of
+   Germany without regard to its conflict of law principles. This 
+   Agreement is prepared and executed and will be interpreted in the 
+   English language only, and no translation of the Agreement into
+   another language will have any effect.
+
+Please sign: __________________________________ Date: ________________


### PR DESCRIPTION
This is a draft proposal for ICLA and CCLA's for external contributors to SSO Projects. It is similar to other agreements of German universities such as [TU Darmstadt](https://dkpro.github.io/contributing/)